### PR TITLE
Remove class or id attribute if it has no content on it

### DIFF
--- a/interactive-export.sketchplugin/Contents/Sketch/attribute-export.js
+++ b/interactive-export.sketchplugin/Contents/Sketch/attribute-export.js
@@ -70,7 +70,10 @@ var exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
 
 Object.defineProperty(exports, "__esModule", {
 	value: true
@@ -126,7 +129,12 @@ function onExportSlices(context) {
 			layerNames.forEach(function (layerName) {
 				var idString = nameToId(layerName);
 				if (svgString.indexOf('id="' + idString + '"') > -1) {
-					svgString = svgString.replace(new RegExp('id="' + idString + '"', 'g'), 'class="' + getClassFromName(layerName) + '" id="' + idString.replace(getClassFromName(layerName).split(' ').join('.'), '').replace('.', '') + '"');
+					var className = getClassFromName(layerName);
+					var newId = idString.replace(getClassFromName(layerName).split(' ').join('.'), '').replace('.', '');
+					var replace = '';
+					if (className) replace += 'class="' + className + '"';
+					if (newId) replace += ' id="' + newId + '"';
+					svgString = svgString.replace(new RegExp('id="' + idString + '"', 'g'), replace);
 				}
 			});
 

--- a/interactive-export.sketchplugin/Contents/Sketch/manifest.json
+++ b/interactive-export.sketchplugin/Contents/Sketch/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.0.1",
   "icon": "icon.png",
   "commands": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-export",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "sketch": ">=3.0"
   },

--- a/src/attribute-export.js
+++ b/src/attribute-export.js
@@ -45,7 +45,12 @@ function onExportSlices(context) {
 			layerNames.forEach((layerName) => {
 				var idString = nameToId(layerName);
 				if (svgString.indexOf('id="' + idString + '"') > -1) {
-					svgString = svgString.replace(new RegExp('id="' + idString + '"', 'g'), 'class="' + getClassFromName(layerName) + '" id="' + idString.replace(getClassFromName(layerName).split(' ').join('.'), '').replace('.', '') + '"');
+					let className = getClassFromName(layerName);
+					let newId = idString.replace(getClassFromName(layerName).split(' ').join('.'), '').replace('.', '');
+					let replace = '';
+					if (className) replace += 'class="' + className + '"';
+					if (newId) replace += ' id="' + newId + '"';
+					svgString = svgString.replace(new RegExp('id="' + idString + '"', 'g'), replace);
 				}
 			})
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 
 
 {
-  "version": "1.0",
+  "version": "1.0.1",
   "icon": "icon.png",
   "commands" : [
     {


### PR DESCRIPTION
The exported svg had a lot of empty class="" and id="" that are not recommendable. This commit fix that issue. 