### PR TITLE
Updated plugin file writing to use NSString.writeToFile_atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Additionally, if you wish to run the plugin every time it is built:
 npm run start
 ```
 
+You may need to update your Sketch defaults to always reload plugins:
+
+```bash
+defaults write com.bohemiancoding.sketch3 AlwaysReloadScript -bool YES
+```
+
 ### Custom Configuration
 
 #### Babel
@@ -169,4 +175,3 @@ skpm log
 ```
 
 The `-f` option causes `skpm log` to not stop when the end of logs is reached, but rather to wait for additional data to be appended to the input
-

--- a/interactive-export.sketchplugin/Contents/Sketch/attribute-export.js
+++ b/interactive-export.sketchplugin/Contents/Sketch/attribute-export.js
@@ -150,8 +150,9 @@ function onExportSlices(context) {
 			var svgAsNsString = NSString.stringWithFormat("%@", svgString);
 			if (writeNonConflictingFile) {
 				svgAsNsString.writeToFile_atomically(buildNonConflictingPath(path), true);
+			} else {
+				svgAsNsString.writeToFile_atomically(path, true);
 			}
-			svgAsNsString.writeToFile_atomically(path, true);
 		}
 	}
 }

--- a/interactive-export.sketchplugin/Contents/Sketch/attribute-export.js
+++ b/interactive-export.sketchplugin/Contents/Sketch/attribute-export.js
@@ -70,16 +70,15 @@ var exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
+/***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
 exports['default'] = function (context) {};
+
+var writeNonConflictingFile = false; // TODO: Use plugin settings here
 
 function saveJSON(obj, filePath) {
 	obj = JSON.parse(JSON.stringify(obj));
@@ -95,6 +94,14 @@ function nameToId(str) {
 
 function getClassFromName(name) {
 	return name.split('.').slice(1).join(' ');
+}
+
+function buildNonConflictingPath(path) {
+	var splitParts = path.split('\\').pop().split('/');
+	var pathToFile = splitParts.slice(0, splitParts.length - 1).join('/');
+	var filenameParts = splitParts.pop().split('.');
+	var newFileName = filenameParts.slice(0, -2).concat([filenameParts[filenameParts.length - 2] + "_attribute_export", filenameParts[filenameParts.length - 1]]).join('.');
+	return pathToFile + '/' + newFileName;
 }
 
 function onExportSlices(context) {
@@ -139,7 +146,12 @@ function onExportSlices(context) {
 			});
 
 			svgString = svgString.replace(/svg width\=\"\d+px" height\=\"\d+px"/, 'svg ');
-			NSString.stringWithString(svgString).writeToFile_atomically_encoding_error(path, true, NSUTF8StringEncoding, nil);
+
+			var svgAsNsString = NSString.stringWithFormat("%@", svgString);
+			if (writeNonConflictingFile) {
+				svgAsNsString.writeToFile_atomically(buildNonConflictingPath(path), true);
+			}
+			svgAsNsString.writeToFile_atomically(path, true);
 		}
 	}
 }

--- a/interactive-export.sketchplugin/Contents/Sketch/manifest.json
+++ b/interactive-export.sketchplugin/Contents/Sketch/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icon": "icon.png",
   "commands": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-export",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "sketch": ">=3.0"
   },

--- a/src/attribute-export.js
+++ b/src/attribute-export.js
@@ -68,8 +68,9 @@ function onExportSlices(context) {
 			const svgAsNsString = NSString.stringWithFormat("%@", svgString);
 			if (writeNonConflictingFile) {
 				svgAsNsString.writeToFile_atomically(buildNonConflictingPath(path), true);
+			} else {
+				svgAsNsString.writeToFile_atomically(path, true);
 			}
-			svgAsNsString.writeToFile_atomically(path, true);
 		}
 	}
 

--- a/src/attribute-export.js
+++ b/src/attribute-export.js
@@ -1,3 +1,4 @@
+var writeNonConflictingFile = false; // TODO: Use plugin settings here
 
 function saveJSON(obj, filePath) {
 	obj = JSON.parse(JSON.stringify(obj));
@@ -13,6 +14,14 @@ function nameToId(str) {
 
 function getClassFromName(name) {
 	return name.split('.').slice(1).join(' ');
+}
+
+function buildNonConflictingPath(path) {
+	const splitParts = path.split('\\').pop().split('/')
+	const pathToFile = splitParts.slice(0, splitParts.length - 1).join('/')
+	const filenameParts = splitParts.pop().split('.');
+	const newFileName = filenameParts.slice(0, -2).concat([filenameParts[filenameParts.length - 2] + "_attribute_export", filenameParts[filenameParts.length - 1]]).join('.')
+	return pathToFile + '/' + newFileName;
 }
 
 function onExportSlices(context) {
@@ -55,7 +64,12 @@ function onExportSlices(context) {
 			})
 
 			svgString = svgString.replace(/svg width\=\"\d+px" height\=\"\d+px"/, 'svg ');
-			NSString.stringWithString(svgString).writeToFile_atomically_encoding_error(path, true, NSUTF8StringEncoding, nil);
+
+			const svgAsNsString = NSString.stringWithFormat("%@", svgString);
+			if (writeNonConflictingFile) {
+				svgAsNsString.writeToFile_atomically(buildNonConflictingPath(path), true);
+			}
+			svgAsNsString.writeToFile_atomically(path, true);
 		}
 	}
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 
 
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icon": "icon.png",
   "commands" : [
     {


### PR DESCRIPTION
The line:

```
NSString.stringWithString(svgString).writeToFile_atomically_encoding_error(path, true, NSUTF8StringEncoding, nil)
```

Was giving me an an error. You can reproduce with something like the following:

```
var errorPtr = MOPointer.alloc().init();
var file = NSString.stringWithString(svgString).writeToFile_atomically_encoding_error(path, true, NSUTF8StringEncoding, nil);
print(str);
print(errorPtr.value())
```

My changes are the only way I can seem to get the SVG to write to my filesystem. I also added a helper method to save the file along-side the original SVG, which people may want if they want to retain the original version of the SVG.

Sketch version 55 and I'm on macOS Catalina (Version 10.15.3).